### PR TITLE
KProfiles: Adapt to A12 style and misc Improvements

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -21,6 +21,5 @@ android_app {
     static_libs: [
         "androidx.core_core",
         "androidx.preference_preference",
-        "org.lineageos.settings.resources",
     ],
 }

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -29,7 +29,7 @@
         android:targetSdkVersion="24"/>
 
     <application
-        android:label="@string/kprofiles_app_name"
+        android:label="@string/kprofiles_title"
         android:persistent="true">
 
         <receiver android:name=".BootCompletedReceiver">

--- a/res/layout/kprofiles.xml
+++ b/res/layout/kprofiles.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2022, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:orientation="vertical"
+              android:layout_height="match_parent"
+              android:layout_width="match_parent">
+
+</LinearLayout>

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -14,14 +14,14 @@
 -->
 <resources>
 
-    <string-array name="kprofile_modes_entries">
-        <item>@string/action_none</item>
+    <string-array name="kprofiles_modes_entries">
+        <item>@string/kprofiles_modes_none</item>
         <item>@string/kprofiles_modes_battery</item>
         <item>@string/kprofiles_modes_balanced</item>
         <item>@string/kprofiles_modes_performance</item>
     </string-array>
 
-    <string-array name="kprofile_modes_values">
+    <string-array name="kprofiles_modes_values">
         <item>0</item>
         <item>1</item>
         <item>2</item>

--- a/res/values/integers.xml
+++ b/res/values/integers.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2022, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+<resources>
+
+     <!-- KProfiles Levels -->
+     <integer name="kprofiles_modes_default">2</integer>
+
+</resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -18,7 +18,7 @@
     <string name="kprofiles_auto_title">Use Auto KProfiles</string>
     <string name="kprofiles_auto_summary">Automatically switch to battery mode when device screen turns off and back to default profile when screen turns on</string>
     <string name="kprofiles_modes_title">KProfiles Modes</string>
-    <string name="kprofiles_modes_summary">Select default mode</string>
+    <string name="kprofiles_modes_none">None</string>
     <string name="kprofiles_modes_battery">Battery</string>
     <string name="kprofiles_modes_balanced">Balanced</string>
     <string name="kprofiles_modes_performance">Performance</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -13,7 +13,6 @@
 -->
 <resources>
 
-    <string name="kprofiles_app_name">kprofiles</string>
     <string name="kprofiles_title">KProfiles</string>
     <string name="kprofiles_summary">A Kernelspace profiles mode manager</string>
     <string name="kprofiles_auto_title">Auto KProfiles</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -14,11 +14,11 @@
 <resources>
 
     <string name="kprofiles_title">KProfiles</string>
-    <string name="kprofiles_summary">A Kernelspace profiles mode manager</string>
-    <string name="kprofiles_auto_title">Auto KProfiles</string>
-    <string name="kprofiles_auto_summary">Automatically switch to battery mode when device screen turns off and back to default profile when screen turns on.</string>
-    <string name="kprofiles_modes_title">Modes</string>
-    <string name="kprofiles_modes_summary">Select default mode.</string>
+    <string name="kprofiles_summary">Managing Kernelspace profiles to achieve balancing in terms of battery backup and performance</string>
+    <string name="kprofiles_auto_title">Use Auto KProfiles</string>
+    <string name="kprofiles_auto_summary">Automatically switch to battery mode when device screen turns off and back to default profile when screen turns on</string>
+    <string name="kprofiles_modes_title">KProfiles Modes</string>
+    <string name="kprofiles_modes_summary">Select default mode</string>
     <string name="kprofiles_modes_battery">Battery</string>
     <string name="kprofiles_modes_balanced">Balanced</string>
     <string name="kprofiles_modes_performance">Performance</string>

--- a/res/xml/kprofiles_settings.xml
+++ b/res/xml/kprofiles_settings.xml
@@ -13,21 +13,21 @@
      limitations under the License.
 -->
 <PreferenceScreen
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:title="@string/kprofiles_title">
+     xmlns:android="http://schemas.android.com/apk/res/android"
+     android:title="@string/kprofiles_title">
 
-    <SwitchPreference
-        android:key="kprofiles_auto"
-        android:defaultValue="false"
-        android:title="@string/kprofiles_auto_title"
-        android:summary="@string/kprofiles_auto_summary" />
+     <SwitchPreference
+          android:key="kprofiles_auto"
+          android:defaultValue="false"
+          android:title="@string/kprofiles_auto_title"
+          android:summary="@string/kprofiles_auto_summary" />
 
      <ListPreference
-          android:defaultValue="0"
-          android:entries="@array/kprofile_modes_entries"
-          android:entryValues="@array/kprofile_modes_values"
           android:key="kprofiles_modes"
+          android:entries="@array/kprofiles_modes_entries"
+          android:entryValues="@array/kprofiles_modes_values"
+          android:defaultValue="@integer/kprofiles_modes_default"
           android:title="@string/kprofiles_modes_title" 
-          android:summary="@string/kprofiles_modes_summary" />
+          android:summary="%s" />
 
 </PreferenceScreen>

--- a/src/com/android/kprofiles/BootCompletedReceiver.java
+++ b/src/com/android/kprofiles/BootCompletedReceiver.java
@@ -40,10 +40,10 @@ public class BootCompletedReceiver extends BroadcastReceiver {
 
         SharedPreferences sharedPrefs = PreferenceManager.getDefaultSharedPreferences(context);
 
-        boolean kProfileaAutoEnabled = sharedPrefs.getBoolean(KPROFILES_AUTO_KEY, false);
-        FileUtils.writeLine(KPROFILES_AUTO_NODE, kProfileaAutoEnabled ? "1" : "0");
-        int kProfileMode = sharedPrefs.getInt(KPROFILES_MODES_KEY, 0);
-        FileUtils.writeLine(KPROFILES_MODES_NODE, kProfileMode > 0 ? "1" : "0");
+        boolean kProfilesAutoEnabled = sharedPrefs.getBoolean(KPROFILES_AUTO_KEY, false);
+        FileUtils.writeLine(KPROFILES_AUTO_NODE, kProfilesAutoEnabled ? "Y" : "N");
+        String kProfileMode = sharedPrefs.getString(KPROFILES_AUTO_KEY, "0");
+        FileUtils.writeLine(KPROFILES_MODES_NODE, kProfileMode);
 
     }
 }

--- a/src/com/android/kprofiles/battery/KprofilesSettingsActivity.java
+++ b/src/com/android/kprofiles/battery/KprofilesSettingsActivity.java
@@ -17,16 +17,18 @@
 package com.android.kprofiles.battery;
 
 import android.os.Bundle;
-import android.preference.PreferenceActivity;
 
-public class KprofilesSettingsActivity extends PreferenceActivity {
+import com.android.settingslib.collapsingtoolbar.CollapsingToolbarBaseActivity;
+import com.android.settingslib.collapsingtoolbar.R;
+
+public class KprofilesSettingsActivity extends CollapsingToolbarBaseActivity {
 
     private static final String TAG_KPROFILES = "kprofiles";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        getFragmentManager().beginTransaction().replace(android.R.id.content,
+        getFragmentManager().beginTransaction().replace(R.id.content_frame,
                 new KprofilesSettingsFragment(), TAG_KPROFILES).commit();
     }
 }

--- a/src/com/android/kprofiles/battery/KprofilesSettingsFragment.java
+++ b/src/com/android/kprofiles/battery/KprofilesSettingsFragment.java
@@ -16,14 +16,19 @@
 
 package com.android.kprofiles.battery;
 
+import android.app.ActionBar;
 import android.content.Context;
 import android.os.Bundle;
+import android.view.LayoutInflater;
 import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.preference.ListPreference;
 import androidx.preference.Preference;
 import androidx.preference.Preference.OnPreferenceChangeListener;
 import androidx.preference.PreferenceFragment;
 import androidx.preference.SwitchPreference;
-import androidx.preference.ListPreference;
 
 import com.android.kprofiles.R;
 import com.android.kprofiles.utils.FileUtils;
@@ -37,11 +42,13 @@ public class KprofilesSettingsFragment extends PreferenceFragment implements
     private static final String KPROFILES_AUTO_NODE = "/sys/module/kprofiles/parameters/auto_kprofiles";
     private static final String KPROFILES_MODES_KEY = "kprofiles_modes";
     private static final String KPROFILES_MODES_NODE = "/sys/module/kprofiles/parameters/mode";
-    private static final String KPROFILES_MODES_DEFAULT = "2";
 
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
         addPreferencesFromResource(R.xml.kprofiles_settings);
+        final ActionBar actionBar = getActivity().getActionBar();
+        actionBar.setDisplayHomeAsUpEnabled(true);
+
         kProfilesAutoPreference = (SwitchPreference) findPreference(KPROFILES_AUTO_KEY);
         if (FileUtils.fileExists(KPROFILES_AUTO_NODE)) {
             kProfilesAutoPreference.setEnabled(true);
@@ -60,7 +67,21 @@ public class KprofilesSettingsFragment extends PreferenceFragment implements
         }
         
     }
-    
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        final View view = LayoutInflater.from(getContext()).inflate(R.layout.kprofiles,
+                container, false);
+        ((ViewGroup) view).addView(super.onCreateView(inflater, container, savedInstanceState));
+        return view;
+    }
+
+    @Override
+    public void onViewCreated(View view, Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+    }
+
     @Override
     public boolean onPreferenceChange(Preference preference, Object newValue) {
         if (KPROFILES_AUTO_KEY.equals(preference.getKey())) {

--- a/src/com/android/kprofiles/battery/KprofilesSettingsFragment.java
+++ b/src/com/android/kprofiles/battery/KprofilesSettingsFragment.java
@@ -65,7 +65,7 @@ public class KprofilesSettingsFragment extends PreferenceFragment implements
     public boolean onPreferenceChange(Preference preference, Object newValue) {
         if (KPROFILES_AUTO_KEY.equals(preference.getKey())) {
             try {
-                FileUtils.writeLine(KPROFILES_AUTO_NODE, (Boolean) newValue ? "1" : "0");
+                FileUtils.writeLine(KPROFILES_AUTO_NODE, (Boolean) newValue ? "Y" : "N");
             } catch(Exception e) { }
 
         } else if (KPROFILES_MODES_KEY.equals(preference.getKey())) {


### PR DESCRIPTION
[1] Adapt to A12 style
[2] Update strings and layout
[3] Correctly restore values after boot completed from sharedPrefs
[4] Drop org.lineageos.settings.resources as it's not needed anymore after this change
